### PR TITLE
Adding Internal-Key for publisher test console CORS to GW

### DIFF
--- a/roles/apim-gateway/templates/carbon-home/repository/conf/deployment.toml.j2
+++ b/roles/apim-gateway/templates/carbon-home/repository/conf/deployment.toml.j2
@@ -106,7 +106,7 @@ auth_header = "Authorization"
 [apim.cors]
 allow_origins = "*"
 allow_methods = ["GET","PUT","POST","DELETE","PATCH","OPTIONS"]
-allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction"]
+allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction","Internal-Key"]
 allow_credentials = false
 
 {% if gw_https_proxy_port is defined %}


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/wso2/api-manager/issues/1496

This will be merged to the fork of Gihan/Ayesh ATM since the 4.2.x branch is not yet merged to wso2/ansible-apim fork.